### PR TITLE
Join ethnicity fix

### DIFF
--- a/analysis/generate_measures_demographics.py
+++ b/analysis/generate_measures_demographics.py
@@ -4,8 +4,8 @@ import pandas as pd
 demographics = ["region", "imd", "ethnicity"]
 df_list = []
 for file in os.listdir('output'):
-    if file.startswith('input_2'):
-        date = file.split('_')[-1][:-4]
+    if file.endswith('joined'):
+        date = file.split('_')[-2][:-4]
 
         file_path = os.path.join('output', file)
         df = pd.read_csv(file_path)

--- a/analysis/generate_measures_demographics.py
+++ b/analysis/generate_measures_demographics.py
@@ -1,11 +1,12 @@
 import os
 import pandas as pd
+import numpy as np
 
 demographics = ["region", "imd", "ethnicity"]
 df_list = []
 for file in os.listdir('output'):
-    if file.endswith('joined'):
-        date = file.split('_')[-2][:-4]
+    if file.startswith('input_2'):
+        date = file.split('_')[-1][:-4]
 
         file_path = os.path.join('output', file)
         df = pd.read_csv(file_path)
@@ -15,6 +16,9 @@ for file in os.listdir('output'):
 
         df_sublist = []
         for var in demographics:
+
+            var_column = df[var]
+            df[var] = df[var].replace(np.nan, "Missing")
 
             population = df.groupby(
                 ["AgeGroup", var]).size().reset_index()

--- a/analysis/join_ethnicity_imd.py
+++ b/analysis/join_ethnicity_imd.py
@@ -11,9 +11,8 @@ for file in os.listdir('output'):
         if file.split('_')[1] != 'ethnicity':
             file_path = os.path.join('output', file)
             df = pd.read_csv(file_path)
-            print(df.shape)
             merged_df = df.merge(ethnicity_imd_df, how='left', on='patient_id')
-            print(merged_df.shape)
-            merged_df.to_csv(file_path + "_joined")
+            
+            merged_df.to_csv(file_path)
 
 

--- a/analysis/join_ethnicity_imd.py
+++ b/analysis/join_ethnicity_imd.py
@@ -11,8 +11,9 @@ for file in os.listdir('output'):
         if file.split('_')[1] != 'ethnicity':
             file_path = os.path.join('output', file)
             df = pd.read_csv(file_path)
-            merged_df = df.merge(ethnicity_imd_df, how='inner', on='patient_id')
-           
-            merged_df.to_csv(file_path)
+            print(df.shape)
+            merged_df = df.merge(ethnicity_imd_df, how='left', on='patient_id')
+            print(merged_df.shape)
+            merged_df.to_csv(file_path + "_joined")
 
 

--- a/analysis/rate_calculation_demographics.py
+++ b/analysis/rate_calculation_demographics.py
@@ -20,11 +20,16 @@ def calculate_rates(df):
 
 
 
-def get_data():
+def get_data(demographic_var):
     p = f"output/measure_{m.id}.csv"
     by_age = pd.read_csv(
         p, usecols=["date", m.numerator, m.denominator] + m.group_by)
     by_age["date"] = pd.to_datetime(by_age["date"])
+
+    #remove people with "Missing" in demographic vars
+    by_age = by_age[by_age[demographic_var] != "Missing"]
+
+
     return by_age
 
 
@@ -48,7 +53,7 @@ def redact_small_numbers(df):
 
 
 def make_table(demographic_var):
-    by_age = get_data()
+    by_age = get_data(demographic_var)
     by_age['age_rates'] = calculate_rates(by_age)
     by_age["European Standard population rate per 100,000"] = by_age.apply(
         standardise_rates_apply, axis=1)

--- a/analysis/time_series_plots_demographics.py
+++ b/analysis/time_series_plots_demographics.py
@@ -28,7 +28,7 @@ for disease in diseases:
         #if imd qcut
         if variable == "imd":
             
-            imd_column = df["imd"]
+            imd_column = pd.to_numeric(df["imd"])
             df["imd"] = pd.qcut(imd_column, q=5,duplicates="drop")
         
             df = df.groupby(by=["date", variable])["European Standard population rate per 100,000"].mean().reset_index()

--- a/project.yaml
+++ b/project.yaml
@@ -53,7 +53,7 @@ actions:
     needs: [generate_cohort_1, generate_cohort_2, generate_cohort_3, generate_cohort_4, generate_cohort_5, generate_cohort_imd_ethnicity]
     outputs:
       highly_sensitive:
-        cohort: output/input_*_joined.csv
+        cohort: output/i*.csv
    
   calculate_measures:
     run: cohortextractor:latest generate_measures --study-definition study_definition

--- a/project.yaml
+++ b/project.yaml
@@ -53,7 +53,7 @@ actions:
     needs: [generate_cohort_1, generate_cohort_2, generate_cohort_3, generate_cohort_4, generate_cohort_5, generate_cohort_imd_ethnicity]
     outputs:
       highly_sensitive:
-        cohort: output/i*.csv
+        cohort: output/input_*_joined.csv
    
   calculate_measures:
     run: cohortextractor:latest generate_measures --study-definition study_definition


### PR DESCRIPTION
This fixes the problem where patients are dropped when ethnicity and imd were joined.

- Now uses a left merge to keep patients that don't exist when ethnicity/imd is fetched.
- Drops patients with missing values for demographic variables when calculating rates (for each demographic var individually).

